### PR TITLE
Harden storm compression contracts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,13 +12,13 @@
     },
     {
       "name": "megastorm",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "source": "./claude/megastorm/",
       "description": "Large-goal autonomous pipeline: decompose into modules, front-load decisions via brainstorming, then design → closed-loop validate → plan → reverse-review → orchestrate → concurrently execute with anti-fake-completion supervision. Global command /megastorm."
     },
     {
       "name": "grillstorm",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "source": "./claude/grillstorm/",
       "description": "Outcome-first pipeline with reverse Grill gates, worktree concurrency, cross-host continuation, and post-delivery probe critique."
     }

--- a/claude/grillstorm/.claude-plugin/marketplace.json
+++ b/claude/grillstorm/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "grillstorm",
-      "version": "0.17.0",
+      "version": "0.19.1",
       "source": "./",
       "description": "Work backward from completion, deliver concurrently, then probe and Grill the result into linked gap cycles."
     }

--- a/claude/grillstorm/.claude-plugin/plugin.json
+++ b/claude/grillstorm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grillstorm",
   "description": "Outcome-first delivery with reverse Grill gates, supervised concurrency, cross-host continuation, and post-delivery probe critique.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "author": {
     "name": "dv"
   },

--- a/claude/grillstorm/skills/grillstorm/SKILL.md
+++ b/claude/grillstorm/skills/grillstorm/SKILL.md
@@ -173,7 +173,11 @@ and exact completion in a compact state contract or `launch-contract.md`. Ask on
 question to approve the uninterrupted run.
 
 After approval, implementation does not ask routine questions. Record unforeseen choices in
-`autonomous-decisions.md`, update revisions and dependencies, and rerun affected closure.
+`autonomous-decisions.md`, update revisions and dependencies, and rerun affected closure. For
+each choice, consider viable options, adopt the recommended option that remains inside the launch
+authority, record its assumptions/risk/affected artifacts before acting, and record its outcome
+afterward. Never pause merely because the choice concerns product behavior, architecture,
+boundaries, interfaces, or replanning.
 
 **Exit:** one approved, internally consistent launch contract.
 
@@ -191,8 +195,12 @@ contract, module, integration, full-suite, and real runtime checks as applicable
 independent Standards and Spec reviews; repair and repeat to closure.
 
 Unavailable authority for destructive, paid, production, or external action is not
-permission. Preserve the failure and exact evidence; never claim a pass. Commit only
-Grillstorm-owned work under the approved Git policy. Never push or deploy without authority.
+permission. Gather only non-mutating evidence for that action, record the affected branch as
+deferred, transitively skip only its dependents, and continue every independent authorized branch.
+Where useful, complete the local reversible implementation and write an exact reality-gate
+runbook without performing the unauthorized action. Preserve the failure and exact evidence;
+never claim a pass. Commit only Grillstorm-owned work under the approved Git policy. Never push
+or deploy without authority.
 
 **Exit:** all applicable work-unit and global gates pass on current revisions.
 
@@ -206,7 +214,10 @@ code exists, tasks/catalog are evidenced, blocking findings are fixed, required 
 runtime behavior is proven, and the report/terminal commit are durable. This is the delivery
 endpoint; a later audit appends history but does not rewrite it.
 
-If incomplete or pausing, update state/report and use handoff. After completion, enter Phase
+If incomplete after all viable branches drain, update state/report with every deferred/skipped
+chain and a precise resume pointer. Do not use handoff merely because one branch is blocked or an
+unforeseen decision arose. Handoff occurs only on explicit user request or when a terminal
+infrastructure failure makes all further safe progress impossible. After completion, enter Phase
 7 when requested or when the default full workflow continues with the user present.
 
 ## Phase 7: Audit Outcomes

--- a/claude/grillstorm/skills/grillstorm/scripts/test_skill_contract.py
+++ b/claude/grillstorm/skills/grillstorm/scripts/test_skill_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_post_launch_unforeseen_choices_do_not_pause():
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    normalized = " ".join(skill.split())
+    required = (
+        "Never pause merely because",
+        "inside the launch authority",
+        "record its outcome",
+        "transitively skip only its dependents",
+        "continue every independent authorized branch",
+    )
+    for phrase in required:
+        assert phrase in normalized
+
+
+def test_handoff_cannot_replace_branch_local_deferral():
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    normalized = " ".join(skill.split())
+    assert "Do not use handoff merely because one branch is blocked" in normalized
+    assert "explicit user request" in normalized
+    assert "all further safe progress impossible" in normalized
+
+
+def test_progressive_disclosure_references_are_routed():
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    required = (
+        "references/upstream-flow.md",
+        "references/project-setup.md",
+        "references/routing.md",
+        "references/spec-closure-and-abstraction.md",
+        "references/task-documents.md",
+        "references/execution.md",
+        "references/post-delivery-probing.md",
+    )
+    for phrase in required:
+        assert phrase in skill
+        assert (ROOT / phrase).is_file()

--- a/claude/megastorm/.claude-plugin/marketplace.json
+++ b/claude/megastorm/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "megastorm",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "source": "./",
       "description": "Chains superpowers brainstorming/writing-plans/executing-plans into a Workflow-driven pipeline for large goals. Explicit /megastorm trigger."
     }

--- a/claude/megastorm/.claude-plugin/plugin.json
+++ b/claude/megastorm/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "megastorm",
   "description": "Large-goal autonomous pipeline: decompose into modules, front-load decisions via brainstorming, then autonomously design → closed-loop validate → plan → reverse-review → orchestrate → concurrently execute with anti-fake-completion supervision. Global command /megastorm. Also ships /cross-exam: evidence-backed completion cross-examination of any delivery.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": {
     "name": "dv"
   }

--- a/claude/megastorm/knowledge/execution-playbook.md
+++ b/claude/megastorm/knowledge/execution-playbook.md
@@ -62,6 +62,9 @@ This phase is interactive.
    `docs/superpowers/runs/<date>-<goal>/`. Persist its `decision-envelope.json` with scope, write
    roots, destructive limits,
    external systems, network, secrets, spending, model substitutions, and acceptance authority.
+   Also freeze a machine-load policy: explicit `max_concurrency` when known, or permission for the
+   orchestrator to select and record a safe value from observed CPU/memory and acceptance-command
+   cost. Phase 1 never asks for this value.
    Initialize with:
    `python3 $ROOT/scripts/decision_ledger.py init <run-dir> <envelope.json>`.
 8. For a goal that eliminates or enforces a whole class, create an exhaustive census before tasks:
@@ -79,6 +82,14 @@ dependents, and continue independent work.
 For stages 1.1-1.5, `status:"escalate"` is a decision proposal. Select, record, apply, and finalize
 the best authorized recommendation; otherwise defer only the affected branch. Stage 1.6 records an
 escalating task, skips its dependent chain, and keeps the rest running.
+
+Every autonomous decision MUST use `decision_ledger.py record` before its action and
+`decision_ledger.py finalize` after the observable outcome. Never edit `decision-ledger.json`
+directly. The script owns authority-basis validation, the single-writer lock, monotonic IDs, three
+atomic write attempts, emergency-journal fallback, and one-time finalization. If both the normal
+ledger and emergency journal are unwritable, perform no further mutations: retain a schema-complete
+degraded in-memory record, drain no new work, and transition directly to the Phase 2 degraded
+report. Lack of durable decision state never grants permission to continue mutating.
 
 Every Workflow stage must:
 
@@ -171,7 +182,9 @@ Persist `retry-ledger.json`, `escalation-ledger.json`, `reality-gate-ledger.json
 - Dispatch every ready task immediately; recompute readiness after every confirmation. Do not add
   a skill-level cap over the Workflow platform cap.
 - If acceptance commands contain machine-heavy local work such as full builds, whole suites, or
-  Docker builds, warn before launch and honor a user-chosen `max_concurrency`; never silently cap.
+  Docker builds, apply the Phase 0 machine-load policy. If no explicit value was frozen, select a
+  safe recommendation from observed CPU/memory and command cost, persist it as an autonomous
+  decision, and continue without asking. Never silently cap.
 - At most one task per isolate/resource group may be in flight. Waiting on a mutex consumes no
   concurrency slot and follows declaration order.
 

--- a/claude/megastorm/scripts/test_megastorm_contract.py
+++ b/claude/megastorm/scripts/test_megastorm_contract.py
@@ -41,6 +41,26 @@ class TestMegastormContract(unittest.TestCase):
         for phrase in required:
             self.assertIn(phrase, combined)
 
+    def test_decisions_cannot_bypass_durable_gateway(self):
+        combined = read("skills/megastorm.md") + read("knowledge/execution-playbook.md")
+        required = (
+            "decision_ledger.py record",
+            "decision_ledger.py finalize",
+            "Never edit `decision-ledger.json` directly",
+            "three",
+            "emergency journal",
+            "perform no further mutations",
+            "degraded",
+        )
+        for phrase in required:
+            self.assertIn(phrase, combined)
+
+    def test_phase1_concurrency_never_requires_a_question(self):
+        playbook = read("knowledge/execution-playbook.md")
+        self.assertIn("machine-load policy", playbook)
+        self.assertIn("continue without asking", playbook)
+        self.assertNotIn("user-chosen `max_concurrency`", playbook)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/claude/megastorm/skills/megastorm.md
+++ b/claude/megastorm/skills/megastorm.md
@@ -97,6 +97,9 @@ End the run after the report. `/cross-exam` remains an explicit, separate comman
   `scriptPath`.
 - Never ask the user during Phase 1. Choose the best authorized recommendation, record it, and
   continue; if authority is insufficient, defer only that branch and its dependents.
+- Never edit `decision-ledger.json` directly. Use `decision_ledger.py record/finalize`; if neither
+  its normal ledger nor emergency journal is writable, stop new mutations and close with a
+  degraded report.
 - Never treat infrastructure failure as business failure or spend business retry budget on it.
 - Never treat environmental proof failure as a code defect. Record a reality gate and keep
   independent/downstream work running when committed interfaces exist.

--- a/codex/grillstorm/SKILL.md
+++ b/codex/grillstorm/SKILL.md
@@ -173,7 +173,11 @@ and exact completion in a compact state contract or `launch-contract.md`. Ask on
 question to approve the uninterrupted run.
 
 After approval, implementation does not ask routine questions. Record unforeseen choices in
-`autonomous-decisions.md`, update revisions and dependencies, and rerun affected closure.
+`autonomous-decisions.md`, update revisions and dependencies, and rerun affected closure. For
+each choice, consider viable options, adopt the recommended option that remains inside the launch
+authority, record its assumptions/risk/affected artifacts before acting, and record its outcome
+afterward. Never pause merely because the choice concerns product behavior, architecture,
+boundaries, interfaces, or replanning.
 
 **Exit:** one approved, internally consistent launch contract.
 
@@ -191,8 +195,12 @@ contract, module, integration, full-suite, and real runtime checks as applicable
 independent Standards and Spec reviews; repair and repeat to closure.
 
 Unavailable authority for destructive, paid, production, or external action is not
-permission. Preserve the failure and exact evidence; never claim a pass. Commit only
-Grillstorm-owned work under the approved Git policy. Never push or deploy without authority.
+permission. Gather only non-mutating evidence for that action, record the affected branch as
+deferred, transitively skip only its dependents, and continue every independent authorized branch.
+Where useful, complete the local reversible implementation and write an exact reality-gate
+runbook without performing the unauthorized action. Preserve the failure and exact evidence;
+never claim a pass. Commit only Grillstorm-owned work under the approved Git policy. Never push
+or deploy without authority.
 
 **Exit:** all applicable work-unit and global gates pass on current revisions.
 
@@ -206,7 +214,10 @@ code exists, tasks/catalog are evidenced, blocking findings are fixed, required 
 runtime behavior is proven, and the report/terminal commit are durable. This is the delivery
 endpoint; a later audit appends history but does not rewrite it.
 
-If incomplete or pausing, update state/report and use handoff. After completion, enter Phase
+If incomplete after all viable branches drain, update state/report with every deferred/skipped
+chain and a precise resume pointer. Do not use handoff merely because one branch is blocked or an
+unforeseen decision arose. Handoff occurs only on explicit user request or when a terminal
+infrastructure failure makes all further safe progress impossible. After completion, enter Phase
 7 when requested or when the default full workflow continues with the user present.
 
 ## Phase 7: Audit Outcomes

--- a/codex/grillstorm/scripts/test_skill_contract.py
+++ b/codex/grillstorm/scripts/test_skill_contract.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_post_launch_unforeseen_choices_do_not_pause():
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    normalized = " ".join(skill.split())
+    required = (
+        "Never pause merely because",
+        "inside the launch authority",
+        "record its outcome",
+        "transitively skip only its dependents",
+        "continue every independent authorized branch",
+    )
+    for phrase in required:
+        assert phrase in normalized
+
+
+def test_handoff_cannot_replace_branch_local_deferral():
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    normalized = " ".join(skill.split())
+    assert "Do not use handoff merely because one branch is blocked" in normalized
+    assert "explicit user request" in normalized
+    assert "all further safe progress impossible" in normalized
+
+
+def test_progressive_disclosure_references_are_routed():
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    required = (
+        "references/upstream-flow.md",
+        "references/project-setup.md",
+        "references/routing.md",
+        "references/spec-closure-and-abstraction.md",
+        "references/task-documents.md",
+        "references/execution.md",
+        "references/post-delivery-probing.md",
+    )
+    for phrase in required:
+        assert phrase in skill
+        assert (ROOT / phrase).is_file()

--- a/codex/megastorm-skill/AGENTS.md
+++ b/codex/megastorm-skill/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — megastorm (Codex port, v0.17.0)
+# AGENTS.md — megastorm (Codex port, v0.17.1)
 
 > Drive a large goal end-to-end: decompose into modules, front-load every human
 > decision, then autonomously design → validate (closed-loop) → plan → reverse-review

--- a/codex/megastorm-skill/PARITY.md
+++ b/codex/megastorm-skill/PARITY.md
@@ -1,4 +1,4 @@
-# Claude v0.17.0 → Codex capability parity
+# Claude v0.17.1 → Codex capability parity
 
 | Capability | Codex implementation |
 |---|---|

--- a/codex/megastorm-skill/SKILL.md
+++ b/codex/megastorm-skill/SKILL.md
@@ -25,7 +25,7 @@ Everything you need sits beside it:
 - `models.example.json` — tier mappings used only when Phase 0 proves every effective
   model source is unlocked; otherwise freeze `inherited` and add no model override
 
-Parity target: Claude Megastorm v0.17.0. This Codex-native port includes environment
+Parity target: Claude Megastorm v0.17.1. This Codex-native port includes environment
 capability classification, census-backed completeness, reality-gate accounting, separate
 infrastructure/business failures, safe run-owned Git integration, and unattended decision
 disclosure. Independent workflows are never invoked or suggested automatically after Phase 2.

--- a/codex/megastorm-skill/execution-playbook.md
+++ b/codex/megastorm-skill/execution-playbook.md
@@ -73,7 +73,9 @@ the approved host argv already owns one. Use `python3`/`sys.executable`; never a
    ever. A mid-run model failure is retry-then-escalate, never silent substitution.
 7. **Freeze authority and decision policy.** Persist `<run-dir>/decision-envelope.json`
    with scope, write roots, destructive limits, external systems, network, secrets,
-   spending, model substitutions, and acceptance authority. Initialize the run ledger:
+   spending, model substitutions, acceptance authority, and a machine-load policy with an
+   explicit `max_concurrency` or permission to select and record one from observed resource
+   capacity. Initialize the run ledger:
    `python3 scripts/decision_ledger.py init <run-dir> <envelope.json>`. This is the final
    ordinary human decision point.
 8. **Class-elimination census:** if the goal claims to remove or enforce an entire class,
@@ -88,6 +90,12 @@ repository convention, blast radius, evidence, maintenance cost, then stable nam
 Persist the recommended authorized choice before acting and finalize it with an
 artifact/event reference. If no choice is authorized, record `deferred`, skip only that
 branch and its dependents, and continue all independent work.
+
+Every autonomous decision MUST use `scripts/decision_ledger.py record` before action and
+`finalize` after its observable outcome. Never edit `decision-ledger.json` directly. The
+script owns authority validation, locking, monotonic IDs, three atomic write attempts,
+emergency fallback, and one-time finalization. If both normal and emergency storage are
+unwritable, perform no further mutations and transition directly to a degraded Phase 2 report.
 
 ### 1.1 Design — fan-out
 One `codex exec` (`think` model) per module: `prompts/design-agent.md` + the module spec
@@ -140,8 +148,9 @@ The runner owns:
   `effective_deps` is supervisor-confirmed. Every ready task dispatches immediately —
   concurrency is UNBOUNDED by default (tasks are LLM calls, not machine-bound work).
   One slow task never stalls its independent siblings. If tasks run machine-heavy local
-  work (builds, whole test suites, docker), the runner prints a warning; pass
-  `--max-workers N` to cap in-flight tasks — the runner never caps silently on its own.
+  work (builds, whole test suites, docker), apply the frozen machine-load policy. When it
+  delegates selection, choose a safe value from observed resources, record it autonomously,
+  and pass `--max-workers N` without asking. The runner never caps silently on its own.
 - **Safe Git isolation:** all tasks run in task worktrees and merge into a run-owned
   integration worktree/ref. The user's checked-out branch, index, and dirty files are never
   staged, committed, stashed, or overwritten. The final report identifies the retained ref.


### PR DESCRIPTION
## What changed

- Force Megastorm autonomous decisions through the locked decision-ledger gateway.
- Fail closed when both normal and emergency decision storage are unavailable.
- Freeze or autonomously select machine-heavy concurrency without Phase 1 questions.
- Restore Grillstorm branch-local deferral and independent-work continuation after launch.
- Prevent handoff from replacing autonomous recovery for a single blocked branch.
- Add compression-equivalence contract tests for Megastorm and both Grillstorm variants.
- Bump Megastorm to 0.17.1 and Grillstorm to 0.19.1.

## Why

The orchestration-context compression preserved most headline rules but weakened several executable safety and unattended-run details. These changes restore the lost behavior and make future compression regressions test-visible.

## Validation

- Claude Megastorm: 93 passed
- Codex Megastorm: 152 passed
- Claude Grillstorm: 173 passed
- Codex Grillstorm: 173 passed
- Total: 591 passed
- git diff --check: passed
